### PR TITLE
**Updated:** VSIX Manifest file to allow support for Visual Studio 2019.

### DIFF
--- a/UntabifyReplacement/source.extension.vsixmanifest
+++ b/UntabifyReplacement/source.extension.vsixmanifest
@@ -10,11 +10,11 @@
         <Tags>Whitespace, Cleanup</Tags>
     </Metadata>
     <Installation InstalledByMsi="false">
-        <InstallationTarget Version="[11.0,16.0]" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Premium" />
-        <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Ultimate" />
+        <InstallationTarget Version="[11.0,17.0]" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Premium" />
+        <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Ultimate" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to work with Visual Studio 2019.

This involved some minor updates to the Manifest file to allow later Versions of Visual Studio.

Original issue: [Issue #9 - Cannot install in VS 2019 community fails](https://github.com/cpmcgrath/UntabifyReplacement/issues/9)

Many thanks to [spocko](https://github.com/spocko) for identifying the changes required! 

Hope this helps!